### PR TITLE
NG9097 & DM9098 eeprom improvements

### DIFF
--- a/batch/eeprom/DM9098_R6M2E6_oak_d_pro_af.json
+++ b/batch/eeprom/DM9098_R6M2E6_oak_d_pro_af.json
@@ -7,6 +7,6 @@
     "productName": "OAK-D-PRO-AF",
     "boardCustom": "",
     "hardwareConf": "F0-FV00-BC001",
-    "boardOptions": 4,
+    "boardOptions": 1048580,
     "version": 7
 }

--- a/batch/eeprom/DM9098_R6M2E6_oak_d_pro_af_pb.json
+++ b/batch/eeprom/DM9098_R6M2E6_oak_d_pro_af_pb.json
@@ -7,6 +7,6 @@
     "productName": "OAK-D-PRO-AF-PB",
     "boardCustom": "",
     "hardwareConf": "F0-FV00-BC002",
-    "boardOptions": 4,
+    "boardOptions": 1048580,
     "version": 7
 }

--- a/batch/eeprom/DM9098_R6M2E6_oak_d_pro_ff.json
+++ b/batch/eeprom/DM9098_R6M2E6_oak_d_pro_ff.json
@@ -7,6 +7,6 @@
     "productName": "OAK-D-PRO-FF",
     "boardCustom": "",
     "hardwareConf": "F1-FV00-BC001",
-    "boardOptions": 4,
+    "boardOptions": 1048580,
     "version": 7
 }

--- a/batch/eeprom/DM9098_R6M2E6_oak_d_pro_ff_c13.json
+++ b/batch/eeprom/DM9098_R6M2E6_oak_d_pro_ff_c13.json
@@ -7,7 +7,7 @@
     "productName": "OAK-D-PRO-FF-C13",
     "boardCustom": "",
     "hardwareConf": "F1-FV00-BC002",
-    "boardOptions": 4,
+    "boardOptions": 1048580,
     "version": 7
 }
 

--- a/batch/eeprom/DM9098_R6M2E6_oak_d_pro_ff_c17.json
+++ b/batch/eeprom/DM9098_R6M2E6_oak_d_pro_ff_c17.json
@@ -7,7 +7,7 @@
     "productName": "OAK-D-PRO-FF-C17",
     "boardCustom": "",
     "hardwareConf": "F1-FV00-BC000",
-    "boardOptions": 4,
+    "boardOptions": 1048580,
     "version": 7
 }
 

--- a/batch/eeprom/DM9098_R6M2E6_oak_d_pro_ff_pb_ff#1.json
+++ b/batch/eeprom/DM9098_R6M2E6_oak_d_pro_ff_pb_ff#1.json
@@ -7,6 +7,6 @@
     "productName": "OAK-D-PRO-FF-PB-FF#1",
     "boardCustom": "",
     "hardwareConf": "F1-FV00-BC002",
-    "boardOptions": 4,
+    "boardOptions": 1048580,
     "version": 7
 }

--- a/batch/eeprom/DM9098_R6M2E6_oak_d_pro_ff_pb_ff#2.json
+++ b/batch/eeprom/DM9098_R6M2E6_oak_d_pro_ff_pb_ff#2.json
@@ -7,6 +7,6 @@
     "productName": "OAK-D-PRO-FF-PB-FF#2",
     "boardCustom": "",
     "hardwareConf": "F1-FV00-BC002",
-    "boardOptions": 4,
+    "boardOptions": 1048580,
     "version": 7
 }

--- a/batch/eeprom/DM9098_R6M2E6_oak_d_pro_w.json
+++ b/batch/eeprom/DM9098_R6M2E6_oak_d_pro_w.json
@@ -7,6 +7,6 @@
     "productName": "OAK-D-PRO-W",
     "boardCustom": "",
     "hardwareConf": "F1-FV01-BC001",
-    "boardOptions": 4,
+    "boardOptions": 1048580,
     "version": 7
 }

--- a/batch/eeprom/DM9098_R6M2E6_oak_d_pro_w_c06.json
+++ b/batch/eeprom/DM9098_R6M2E6_oak_d_pro_w_c06.json
@@ -7,7 +7,7 @@
     "productName": "OAK-D-PRO-W-C06",
     "boardCustom": "",
     "hardwareConf": "F1-FV01-BC000",
-    "boardOptions": 4,
+    "boardOptions": 1048580,
     "version": 7
 }
 

--- a/batch/eeprom/DM9098_R6M2E6_oak_d_pro_w_c16.json
+++ b/batch/eeprom/DM9098_R6M2E6_oak_d_pro_w_c16.json
@@ -7,7 +7,7 @@
     "productName": "OAK-D-PRO-W-C16",
     "boardCustom": "",
     "hardwareConf": "F1-FV01-BC000",
-    "boardOptions": 4,
+    "boardOptions": 1048580,
     "version": 7
 }
 

--- a/batch/eeprom/DM9098_R6M2E6_oak_d_pro_w_ov9782.json
+++ b/batch/eeprom/DM9098_R6M2E6_oak_d_pro_w_ov9782.json
@@ -7,6 +7,6 @@
     "productName": "OAK-D-PRO-W-OV9782",
     "boardCustom": "",
     "hardwareConf": "F1-FV01-BC001",
-    "boardOptions": 4,
+    "boardOptions": 1048580,
     "version": 7
 }

--- a/batch/eeprom/DM9098_R6M2E6_oak_d_s2_af.json
+++ b/batch/eeprom/DM9098_R6M2E6_oak_d_s2_af.json
@@ -7,6 +7,6 @@
     "productName": "OAK-D-S2-AF",
     "boardCustom": "",
     "hardwareConf": "F0-FV00-BC001",
-    "boardOptions": 4,
+    "boardOptions": 1048580,
     "version": 7
 }

--- a/batch/eeprom/DM9098_R6M2E6_oak_d_s2_ff.json
+++ b/batch/eeprom/DM9098_R6M2E6_oak_d_s2_ff.json
@@ -7,7 +7,7 @@
     "productName": "OAK-D-S2-FF",
     "boardCustom": "",
     "hardwareConf": "F1-FV00-BC001",
-    "boardOptions": 4,
+    "boardOptions": 1048580,
     "version": 7
 }
 

--- a/batch/eeprom/DM9098_R6M2E6_oak_d_w.json
+++ b/batch/eeprom/DM9098_R6M2E6_oak_d_w.json
@@ -7,7 +7,7 @@
     "productName": "OAK-D-W",
     "boardCustom": "",
     "hardwareConf": "F1-FV01-BC000",
-    "boardOptions": 4,
+    "boardOptions": 1048580,
     "version": 7
 }
 

--- a/batch/eeprom/DM9098_R6M2E6_oak_d_w_c15.json
+++ b/batch/eeprom/DM9098_R6M2E6_oak_d_w_c15.json
@@ -7,7 +7,7 @@
     "productName": "OAK-D-W-C15",
     "boardCustom": "",
     "hardwareConf": "F1-FV01-BC000",
-    "boardOptions": 4,
+    "boardOptions": 1048580,
     "version": 7
 }
 

--- a/batch/eeprom/NG9097_R3M2E2_oak_d_pro_poe_af.json
+++ b/batch/eeprom/NG9097_R3M2E2_oak_d_pro_poe_af.json
@@ -7,6 +7,6 @@
     "productName": "OAK-D-PRO-POE-AF",
     "boardCustom": "",
     "hardwareConf": "F0-FV00-BC000",
-    "boardOptions": 3,
+    "boardOptions": 7,
     "version": 7
 }

--- a/batch/eeprom/NG9097_R3M2E2_oak_d_pro_poe_custom.json
+++ b/batch/eeprom/NG9097_R3M2E2_oak_d_pro_poe_custom.json
@@ -7,6 +7,6 @@
     "productName": "OAK-D-PRO-POE-CUSTOM",
     "boardCustom": "",
     "hardwareConf": "F1-FV00-BC001",
-    "boardOptions": 3,
+    "boardOptions": 7,
     "version": 7
 }

--- a/batch/eeprom/NG9097_R3M2E2_oak_d_pro_poe_ff.json
+++ b/batch/eeprom/NG9097_R3M2E2_oak_d_pro_poe_ff.json
@@ -7,6 +7,6 @@
     "productName": "OAK-D-PRO-POE-FF",
     "boardCustom": "",
     "hardwareConf": "F1-FV00-BC000",
-    "boardOptions": 3,
+    "boardOptions": 7,
     "version": 7
 }

--- a/batch/eeprom/NG9097_R3M2E2_oak_d_pro_w_poe.json
+++ b/batch/eeprom/NG9097_R3M2E2_oak_d_pro_w_poe.json
@@ -7,6 +7,6 @@
     "productName": "OAK-D-PRO-W-POE",
     "boardCustom": "",
     "hardwareConf": "F1-FV01-BC000",
-    "boardOptions": 3,
+    "boardOptions": 7,
     "version": 7
 }

--- a/batch/eeprom/NG9097_R3M2E2_oak_d_pro_w_poe_custom.json
+++ b/batch/eeprom/NG9097_R3M2E2_oak_d_pro_w_poe_custom.json
@@ -7,6 +7,6 @@
     "productName": "OAK-D-PRO-W-POE-CUSTOM",
     "boardCustom": "",
     "hardwareConf": "F1-FV01-BC001",
-    "boardOptions": 3,
+    "boardOptions": 7,
     "version": 7
 }

--- a/batch/eeprom/NG9097_R4M2E3_BNO086_oak_d_pro_poe_af.json
+++ b/batch/eeprom/NG9097_R4M2E3_BNO086_oak_d_pro_poe_af.json
@@ -7,6 +7,6 @@
     "productName": "OAK-D-PRO-POE-AF",
     "boardCustom": "",
     "hardwareConf": "F0-FV00-BC001",
-    "boardOptions": 3,
+    "boardOptions": 7,
     "version": 7
 }

--- a/batch/eeprom/NG9097_R4M2E3_BNO086_oak_d_pro_poe_af_c18.json
+++ b/batch/eeprom/NG9097_R4M2E3_BNO086_oak_d_pro_poe_af_c18.json
@@ -7,6 +7,6 @@
     "productName": "OAK-D-PRO-POE-AF-C18",
     "boardCustom": "",
     "hardwareConf": "F0-FV00-BC001",
-    "boardOptions": 3,
+    "boardOptions": 7,
     "version": 7
 }

--- a/batch/eeprom/NG9097_R4M2E3_BNO086_oak_d_pro_poe_ff.json
+++ b/batch/eeprom/NG9097_R4M2E3_BNO086_oak_d_pro_poe_ff.json
@@ -7,6 +7,6 @@
     "productName": "OAK-D-PRO-POE-FF",
     "boardCustom": "",
     "hardwareConf": "F1-FV00-BC001",
-    "boardOptions": 3,
+    "boardOptions": 7,
     "version": 7
 }

--- a/batch/eeprom/NG9097_R4M2E3_BNO086_oak_d_pro_w_poe.json
+++ b/batch/eeprom/NG9097_R4M2E3_BNO086_oak_d_pro_w_poe.json
@@ -7,6 +7,6 @@
     "productName": "OAK-D-PRO-W-POE",
     "boardCustom": "",
     "hardwareConf": "F1-FV01-BC001",
-    "boardOptions": 3,
+    "boardOptions": 7,
     "version": 7
 }

--- a/batch/eeprom/NG9097_R4M2E3_BNO086_oak_d_s2_poe_af.json
+++ b/batch/eeprom/NG9097_R4M2E3_BNO086_oak_d_s2_poe_af.json
@@ -7,6 +7,6 @@
     "productName": "OAK-D-S2-POE-AF",
     "boardCustom": "",
     "hardwareConf": "F0-FV00-BC001",
-    "boardOptions": 3,
+    "boardOptions": 7,
     "version": 7
 }

--- a/batch/eeprom/NG9097_R4M2E3_BNO086_oak_d_s2_poe_ff.json
+++ b/batch/eeprom/NG9097_R4M2E3_BNO086_oak_d_s2_poe_ff.json
@@ -7,6 +7,6 @@
     "productName": "OAK-D-S2-POE-FF",
     "boardCustom": "",
     "hardwareConf": "F1-FV00-BC001",
-    "boardOptions": 3,
+    "boardOptions": 7,
     "version": 7
 }

--- a/batch/eeprom/NG9097_R4M2E3_BNO086_oak_d_w_poe.json
+++ b/batch/eeprom/NG9097_R4M2E3_BNO086_oak_d_w_poe.json
@@ -7,6 +7,6 @@
     "productName": "OAK-D-W-POE",
     "boardCustom": "",
     "hardwareConf": "F1-FV01-BC001",
-    "boardOptions": 3,
+    "boardOptions": 7,
     "version": 7
 }

--- a/batch/eeprom/NG9097_R4M2E4_BNO086_oak_d_pro_poe_af.json
+++ b/batch/eeprom/NG9097_R4M2E4_BNO086_oak_d_pro_poe_af.json
@@ -7,6 +7,6 @@
     "productName": "OAK-D-PRO-POE-AF",
     "boardCustom": "",
     "hardwareConf": "F0-FV00-BC001",
-    "boardOptions": 3,
+    "boardOptions": 7,
     "version": 7
 }

--- a/batch/eeprom/NG9097_R4M2E4_BNO086_oak_d_pro_poe_af_c18.json
+++ b/batch/eeprom/NG9097_R4M2E4_BNO086_oak_d_pro_poe_af_c18.json
@@ -7,6 +7,6 @@
     "productName": "OAK-D-PRO-POE-AF-C18",
     "boardCustom": "",
     "hardwareConf": "F0-FV00-BC001",
-    "boardOptions": 3,
+    "boardOptions": 7,
     "version": 7
 }

--- a/batch/eeprom/NG9097_R4M2E4_BNO086_oak_d_pro_poe_ff.json
+++ b/batch/eeprom/NG9097_R4M2E4_BNO086_oak_d_pro_poe_ff.json
@@ -7,6 +7,6 @@
     "productName": "OAK-D-PRO-POE-FF",
     "boardCustom": "",
     "hardwareConf": "F1-FV00-BC001",
-    "boardOptions": 3,
+    "boardOptions": 7,
     "version": 7
 }

--- a/batch/eeprom/NG9097_R4M2E4_BNO086_oak_d_pro_w_poe.json
+++ b/batch/eeprom/NG9097_R4M2E4_BNO086_oak_d_pro_w_poe.json
@@ -7,6 +7,6 @@
     "productName": "OAK-D-PRO-W-POE",
     "boardCustom": "",
     "hardwareConf": "F1-FV01-BC001",
-    "boardOptions": 3,
+    "boardOptions": 7,
     "version": 7
 }

--- a/batch/eeprom/NG9097_R4M2E4_BNO086_oak_d_s2_poe_af.json
+++ b/batch/eeprom/NG9097_R4M2E4_BNO086_oak_d_s2_poe_af.json
@@ -7,6 +7,6 @@
     "productName": "OAK-D-S2-POE-AF",
     "boardCustom": "",
     "hardwareConf": "F0-FV00-BC001",
-    "boardOptions": 3,
+    "boardOptions": 7,
     "version": 7
 }

--- a/batch/eeprom/NG9097_R4M2E4_BNO086_oak_d_s2_poe_ff.json
+++ b/batch/eeprom/NG9097_R4M2E4_BNO086_oak_d_s2_poe_ff.json
@@ -7,6 +7,6 @@
     "productName": "OAK-D-S2-POE-FF",
     "boardCustom": "",
     "hardwareConf": "F1-FV00-BC001",
-    "boardOptions": 3,
+    "boardOptions": 7,
     "version": 7
 }

--- a/batch/eeprom/NG9097_R4M2E4_BNO086_oak_d_w_poe.json
+++ b/batch/eeprom/NG9097_R4M2E4_BNO086_oak_d_w_poe.json
@@ -7,6 +7,6 @@
     "productName": "OAK-D-W-POE",
     "boardCustom": "",
     "hardwareConf": "F1-FV01-BC001",
-    "boardOptions": 3,
+    "boardOptions": 7,
     "version": 7
 }


### PR DESCRIPTION
- NG9097 - Added missing 4Lane MIPI camera config CAM_CONF_1 board option
- DM9098 - Added missing PMIC_CONF_1 board option
