### PR TITLE
Fix oak_1_ff product name

### DIFF
--- a/batch/eeprom/NG9093_R3M0E4_oak_1_ff.json
+++ b/batch/eeprom/NG9093_R3M0E4_oak_1_ff.json
@@ -1,10 +1,10 @@
 {
     "batchName": "Maxwell",
     "batchTime": 0,
-    "boardConf": "nIR-C01M00-00",
+    "boardConf": "nIR-C20M99-00",
     "boardName": "NG9093",
     "boardRev": "R3M0E4",
-    "productName": "OAK-1-LITE-FF",
+    "productName": "OAK-1-FF",
     "boardCustom": "",
     "hardwareConf": "F1-FV00-BC000",
     "boardOptions": 0,


### PR DESCRIPTION
Same changes as #20 but based on `main`