### PR TITLE
Test OAK-FFC boards the same way as OAK-1

### DIFF
--- a/batch/oak_ffc_1p.json
+++ b/batch/oak_ffc_1p.json
@@ -2,7 +2,7 @@
     "title": "OAK-FFC 1P",
     "description": "OAK-FFC 1P",
     "image": "images/oak_ffc_1p.jpg",
-    "test_type": "OAK-FFC-1P",
+    "test_type": "OAK-1",
     "options": {"bootloader": "usb"},
     "variants": [
         {

--- a/batch/oak_ffc_3p.json
+++ b/batch/oak_ffc_3p.json
@@ -2,7 +2,7 @@
     "title": "OAK FFC-3P",
     "description": "OAK FFC-3P",
     "image": "images/oak_d_ffc_3p.jpg",
-    "test_type": "OAK-FFC-3P",
+    "test_type": "OAK-1",
     "options": {"bootloader": "usb"},
     "variants": [
         {

--- a/batch/oak_ffc_4p.json
+++ b/batch/oak_ffc_4p.json
@@ -2,7 +2,7 @@
     "title": "OAK FFC-4P",
     "description": "OAK FFC-4P",
     "image": "images/oak_d_ffc_4p.jpg",
-    "test_type": "OAK-FFC-4P",
+    "test_type": "OAK-1",
     "options": {"bootloader": "usb"},
     "variants": [
         {

--- a/batch/oak_ffc_4p_poe.json
+++ b/batch/oak_ffc_4p_poe.json
@@ -2,7 +2,7 @@
     "title": "OAK FFC-4P PoE",
     "description": "OAK FFC-4P PoE",
     "image": "images/oak_d_ffc_4p_poe.jpg",
-    "test_type": "OAK-FFC-4P-POE",
+    "test_type": "OAK-1-POE",
     "options": {"bootloader": "poe"},
     "variants": [
         {


### PR DESCRIPTION
[Test UI script](https://github.com/luxonis/depthai/blob/445fd8f4343cb254c1bebb1266f80eccb51afbfc/test_ui.py) uses `test_type` to determine what tests to run. As of today we don't test image sensors with OAK-FFC. After this change, OAK-FFC boards will be tested the same way as OAK-1 (with one RGB camera).
