### PR TITLE
Added oak-d-w-poe-c23

### DIFF
--- a/batch/eeprom/NG9097_R4M2E4_BNO086_oak_d_w_poe_c23.json
+++ b/batch/eeprom/NG9097_R4M2E4_BNO086_oak_d_w_poe_c23.json
@@ -1,0 +1,12 @@
+{
+    "batchName": "",
+    "batchTime": 0,
+    "boardConf": "nIR-C00M00-00",
+    "boardName": "NG9097",
+    "boardRev": "R4M2E4",
+    "productName": "OAK-D-W-POE-C23",
+    "boardCustom": "",
+    "hardwareConf": "F1-FV01-BC001",
+    "boardOptions": 7,
+    "version": 7
+}

--- a/batch/eeprom/NG9097_R4M2E4_BNO086_oak_d_w_poe_c23.json
+++ b/batch/eeprom/NG9097_R4M2E4_BNO086_oak_d_w_poe_c23.json
@@ -1,7 +1,7 @@
 {
     "batchName": "",
     "batchTime": 0,
-    "boardConf": "nIR-C00M00-00",
+    "boardConf": "nIR-C21M08-00",
     "boardName": "NG9097",
     "boardRev": "R4M2E4",
     "productName": "OAK-D-W-POE-C23",

--- a/batch/oak_d_poe.json
+++ b/batch/oak_d_poe.json
@@ -48,6 +48,12 @@
             "board_config_file": "OAK-D-POE-W.json"
         },
         {
+            "title":"OAK-D W PoE C23 (NG9097 R4M2E4 BNO086)",
+            "description": "OAK-D WideLens PoE C23 (matte black enclosure), based on NG9097 R4M2E4 board with BNO086 IMU",
+            "eeprom":"eeprom/NG9097_R4M2E4_BNO086_oak_d_w_poe_c23.json",
+            "board_config_file": "OAK-D-POE-W.json"
+        },
+        {
             "title":"OAK-D W PoE 97 (NG9097 R4M2E4 BMI270)",
             "description": "OAK-D WideLens PoE 97, based on NG9097 R4M2E4 board with BMI270 IMU (previously C12)",
             "eeprom":"eeprom/NG9097_R4M2E4_BMI270_oak_d_w_poe_97.json",


### PR DESCRIPTION
The eeprom file is the same as for oak-d-w-poe, just the `productName` has changed.