### PR TITLE
Added OAK-D-SR-PoE R2M2E2 & R3M2E3 (EL2086) configs

### DIFF
--- a/batch/eeprom/EL2086_R2M2E2_oak_d_sr_poe.json
+++ b/batch/eeprom/EL2086_R2M2E2_oak_d_sr_poe.json
@@ -1,0 +1,12 @@
+{
+    "batchName": "Maxwell",
+    "batchTime": 0,
+    "boardConf": "nIR-C80M00-00",
+    "boardName": "EL2086",
+    "boardRev": "R2M2E2",
+    "productName": "OAK-D-SR-POE",
+    "boardCustom": "",
+    "hardwareConf": "F1-FV00-BC000",
+    "boardOptions": 257,
+    "version": 7
+}

--- a/batch/eeprom/EL2086_R3M2E3_oak_d_sr_poe.json
+++ b/batch/eeprom/EL2086_R3M2E3_oak_d_sr_poe.json
@@ -1,0 +1,12 @@
+{
+    "batchName": "Maxwell",
+    "batchTime": 0,
+    "boardConf": "nIR-C80M00-00",
+    "boardName": "EL2086",
+    "boardRev": "R3M2E3",
+    "productName": "OAK-D-SR-POE",
+    "boardCustom": "",
+    "hardwareConf": "F1-FV00-BC000",
+    "boardOptions": 257,
+    "version": 7
+}

--- a/batch/oak_d_sr_poe.json
+++ b/batch/oak_d_sr_poe.json
@@ -6,6 +6,18 @@
     "options": {"bootloader": "poe", "imu": true, "usb3": false, "eth": true},
     "variants": [
         {
+            "title":"OAK-D SR PoE (EL2086 R3M2E3)",
+            "description": "OAK-D SR PoE, based on EL2086 R3M2E3 board with ToF sensor",
+            "eeprom":"eeprom/EL2086_R3M2E3_oak_d_sr_poe.json",
+            "board_config_file": "OAK-D-SR-POE.json"
+        },
+        {
+            "title":"OAK-D SR PoE (EL2086 R2M2E2)",
+            "description": "OAK-D SR PoE, based on EL2086 R2M2E2 board with ToF sensor",
+            "eeprom":"eeprom/EL2086_R2M2E2_oak_d_sr_poe.json",
+            "board_config_file": "OAK-D-SR-POE.json"
+        },
+        {
             "title":"OAK-D SR PoE (EL2086 R1M1E1)",
             "description": "OAK-D SR PoE, based on EL2086 R1M1E1 board with ToF sensor",
             "eeprom":"eeprom/EL2086_R1M1E1_oak_d_sr_poe.json",


### PR DESCRIPTION
Only layout optimization for R2M2E2 & R3M2E3 - no software changes needed.