### PR TITLE
Added config for OAK-D-PRO PoE FF C32 (NG9097 R4M2E4)

### DIFF
--- a/batch/eeprom/NG9097_R4M2E4_BNO086_oak_d_pro_poe_ff_c32.json
+++ b/batch/eeprom/NG9097_R4M2E4_BNO086_oak_d_pro_poe_ff_c32.json
@@ -1,12 +1,12 @@
 {
     "batchName": "",
     "batchTime": 0,
-    "boardConf": "nIR-C21M00-00",
+    "boardConf": "nIR-C21M08-00",
     "boardName": "NG9097",
     "boardRev": "R4M2E4",
     "productName": "OAK-D-PRO-POE-FF-C32",
     "boardCustom": "",
-    "hardwareConf": "F1-FV00-BC000",
+    "hardwareConf": "F1-FV00-BC010",
     "boardOptions": 7,
     "version": 7
 }

--- a/batch/eeprom/NG9097_R4M2E4_BNO086_oak_d_pro_poe_ff_c32.json
+++ b/batch/eeprom/NG9097_R4M2E4_BNO086_oak_d_pro_poe_ff_c32.json
@@ -1,0 +1,12 @@
+{
+    "batchName": "",
+    "batchTime": 0,
+    "boardConf": "nIR-C21M00-00",
+    "boardName": "NG9097",
+    "boardRev": "R4M2E4",
+    "productName": "OAK-D-PRO-POE-FF-C32",
+    "boardCustom": "",
+    "hardwareConf": "F1-FV00-BC000",
+    "boardOptions": 7,
+    "version": 7
+}

--- a/batch/oak_d_pro_poe.json
+++ b/batch/oak_d_pro_poe.json
@@ -138,6 +138,12 @@
             "board_config_file": "OAK-D-PRO-POE.json"
         },
         {
+            "title":"OAK-D Pro PoE FF C32 (NG9097 R4M2E4 BNO086)",
+            "description": "OAK-D Pro PoE C32 FixedFocus based on NG9097 R4M2E4 and BNO086 IMU",
+            "eeprom":"eeprom/NG9097_R4M2E4_BNO086_oak_d_pro_poe_ff_c32.json",
+            "board_config_file": "OAK-D-PRO-POE.json"
+        },
+        {
             "title":"OAK-D Pro W PoE (NG9097 R3M2E2)",
             "description": "OAK-D Pro PoE WideLens based on NG9097 R3M2E2",
             "eeprom":"eeprom/NG9097_R3M2E2_oak_d_pro_w_poe.json",


### PR DESCRIPTION
Rework from C18 to C32 (central RGB CCM changed from AF to FF model).