### PR TITLE
Added board configurations for OAK-D Pro (DM9098) R8M2E8 revision

### DIFF
--- a/batch/eeprom/DM9098_R8M2E8_oak_d_pro_af.json
+++ b/batch/eeprom/DM9098_R8M2E8_oak_d_pro_af.json
@@ -1,0 +1,12 @@
+{
+    "batchName": "",
+    "batchTime": 0,
+    "boardConf": "IR-C21M08-00",
+    "boardName": "DM9098",
+    "boardRev": "R8M2E8",
+    "productName": "OAK-D-PRO-AF",
+    "boardCustom": "",
+    "hardwareConf": "F0-FV00-BC000",
+    "boardOptions": 1048580,
+    "version": 7
+}

--- a/batch/eeprom/DM9098_R8M2E8_oak_d_pro_ff.json
+++ b/batch/eeprom/DM9098_R8M2E8_oak_d_pro_ff.json
@@ -1,0 +1,12 @@
+{
+    "batchName": "",
+    "batchTime": 0,
+    "boardConf": "IR-C21M08-00",
+    "boardName": "DM9098",
+    "boardRev": "R8M2E8",
+    "productName": "OAK-D-PRO-FF",
+    "boardCustom": "",
+    "hardwareConf": "F1-FV00-BC000",
+    "boardOptions": 1048580,
+    "version": 7
+}

--- a/batch/eeprom/DM9098_R8M2E8_oak_d_pro_w.json
+++ b/batch/eeprom/DM9098_R8M2E8_oak_d_pro_w.json
@@ -1,0 +1,12 @@
+{
+    "batchName": "",
+    "batchTime": 0,
+    "boardConf": "IR-C21M08-00",
+    "boardName": "DM9098",
+    "boardRev": "R8M2E8",
+    "productName": "OAK-D-PRO-W",
+    "boardCustom": "",
+    "hardwareConf": "F1-FV01-BC000",
+    "boardOptions": 1048580,
+    "version": 7
+}

--- a/batch/eeprom/DM9098_R8M2E8_oak_d_pro_w_97.json
+++ b/batch/eeprom/DM9098_R8M2E8_oak_d_pro_w_97.json
@@ -1,0 +1,12 @@
+{
+    "batchName": "",
+    "batchTime": 0,
+    "boardConf": "IR-C11M08-00",
+    "boardName": "DM9098",
+    "boardRev": "R8M2E8",
+    "productName": "OAK-D-PRO-W-97",
+    "boardCustom": "",
+    "hardwareConf": "F1-FV01-BC000",
+    "boardOptions": 1048580,
+    "version": 7
+}

--- a/batch/oak_d_pro.json
+++ b/batch/oak_d_pro.json
@@ -24,6 +24,12 @@
             "board_config_file": "OAK-D-PRO-W.json"
         },
         {
+            "title":"OAK-D Pro W 97 (DM9098 R8M2E8)",
+            "description": "OAK-D Pro Wide 97 with center OV9782 camera",
+            "eeprom":"eeprom/DM9098_R8M2E8_oak_d_pro_w_97.json",
+            "board_config_file": "OAK-D-PRO-W-97.json"
+        },
+        {
             "title":"OAK-D Pro AF (DM9098 R7M2E7)",
             "description": "OAK-D Pro, AutoFocus",
             "eeprom":"eeprom/DM9098_R7M2E7_oak_d_pro_af.json",

--- a/batch/oak_d_pro.json
+++ b/batch/oak_d_pro.json
@@ -6,6 +6,12 @@
     "options": {"bootloader": "header_usb", "imu": true},
     "variants": [
         {
+            "title":"OAK-D Pro FF (DM9098 R8M2E8)",
+            "description": "OAK-D Pro, Fixed Focus",
+            "eeprom":"eeprom/DM9098_R8M2E8_oak_d_pro_ff.json",
+            "board_config_file": "OAK-D-PRO.json"
+        },
+        {
             "title":"OAK-D Pro W (DM9098 R8M2E8)",
             "description": "OAK-D Pro Wide with center IMX378 camera",
             "eeprom":"eeprom/DM9098_R8M2E8_oak_d_pro_w.json",

--- a/batch/oak_d_pro.json
+++ b/batch/oak_d_pro.json
@@ -6,6 +6,12 @@
     "options": {"bootloader": "header_usb", "imu": true},
     "variants": [
         {
+            "title":"OAK-D Pro W (DM9098 R8M2E8)",
+            "description": "OAK-D Pro Wide with center IMX378 camera",
+            "eeprom":"eeprom/DM9098_R8M2E8_oak_d_pro_w.json",
+            "board_config_file": "OAK-D-PRO-W.json"
+        },
+        {
             "title":"OAK-D Pro AF (DM9098 R7M2E7)",
             "description": "OAK-D Pro, AutoFocus",
             "eeprom":"eeprom/DM9098_R7M2E7_oak_d_pro_af.json",

--- a/batch/oak_d_pro.json
+++ b/batch/oak_d_pro.json
@@ -12,6 +12,12 @@
             "board_config_file": "OAK-D-PRO.json"
         },
         {
+            "title":"OAK-D Pro AF (DM9098 R8M2E8)",
+            "description": "OAK-D Pro, AutoFocus",
+            "eeprom":"eeprom/DM9098_R8M2E8_oak_d_pro_af.json",
+            "board_config_file": "OAK-D-PRO.json"
+        },
+        {
             "title":"OAK-D Pro W (DM9098 R8M2E8)",
             "description": "OAK-D Pro Wide with center IMX378 camera",
             "eeprom":"eeprom/DM9098_R8M2E8_oak_d_pro_w.json",


### PR DESCRIPTION
Added configurations for the following boards:

- OAK-D Pro W
- OAK-D Pro FF
- OAK-D Pro AF
- OAK-D Pro W 97