### PR TITLE
Added missing FFC camera configs

### DIFF
--- a/batch/oak_ffc_1p_poe.json
+++ b/batch/oak_ffc_1p_poe.json
@@ -8,7 +8,8 @@
         {
             "title":"OAK-FFC 1P PoE (BW2098 R4M1E3)",
             "description": "OAK-FFC 1P PoE",
-            "eeprom":"eeprom/BW2098_R4M1E3_oak_ffc_1p_poe.json"
+            "eeprom":"eeprom/BW2098_R4M1E3_oak_ffc_1p_poe.json",
+            "board_config_file": "OAK-FFC-1P.json"
         }
     ]
 }

--- a/batch/oak_ffc_3p.json
+++ b/batch/oak_ffc_3p.json
@@ -3,19 +3,13 @@
     "description": "OAK FFC-3P",
     "image": "images/oak_d_ffc_3p.jpg",
     "test_type": "OAK-1",
-    "options": {
-        "bootloader": "usb",
-        "imu": true,
-        "usb3": true,
-        "cameras": [
-            {"socket": "CAM_C", "name": "rgb", "type": "color"}
-        ]
-    },
+    "options": {"bootloader": "usb", "imu": true, "usb3": true},
     "variants": [
         {
             "title":"OAK-FFC 3P (DM1090 R3M0E3)",
             "description": "OAK-FFC 3P",
-            "eeprom":"eeprom/DM1090_R3M0E3_oak_ffc_3p.json"
+            "eeprom":"eeprom/DM1090_R3M0E3_oak_ffc_3p.json",
+            "board_config_file": "OAK-FFC-3P.json"
         }
     ]
 }

--- a/batch/oak_ffc_4p.json
+++ b/batch/oak_ffc_4p.json
@@ -3,26 +3,25 @@
     "description": "OAK FFC-4P",
     "image": "images/oak_d_ffc_4p.jpg",
     "test_type": "OAK-1",
-    "options": {"bootloader": "usb", "imu": true,
-        "cameras": [
-            {"name": "rgb", "type": "color", "socket": "CAM_A"}
-        ]
-    },
+    "options": {"bootloader": "usb", "imu": true},
     "variants": [
         {
             "title":"OAK-FFC 4P (DD2090 R7M1E7)",
             "description": "OAK-FFC 4P",
-            "eeprom":"eeprom/DD2090_R7M1E7_oak_ffc_4p.json"
+            "eeprom":"eeprom/DD2090_R7M1E7_oak_ffc_4p.json",
+            "board_config_file": "OAK-FFC-4P.json"
         },
         {
             "title":"OAK-FFC 4P (DD2090 R5M1E5)",
             "description": "OAK-FFC 4P",
-            "eeprom":"eeprom/DD2090_R5M1E5_oak_ffc_4p.json"
+            "eeprom":"eeprom/DD2090_R5M1E5_oak_ffc_4p.json",
+            "board_config_file": "OAK-FFC-4P.json"
         },
         {
             "title":"OAK-FFC 4P (DD2090 R4M1E4)",
             "description": "OAK-FFC 4P",
-            "eeprom":"eeprom/DD2090_R4M1E4_oak_ffc_4p.json"
+            "eeprom":"eeprom/DD2090_R4M1E4_oak_ffc_4p.json",
+            "board_config_file": "OAK-FFC-4P.json"
         }
     ]
 }

--- a/batch/oak_ffc_4p_poe.json
+++ b/batch/oak_ffc_4p_poe.json
@@ -8,12 +8,14 @@
         {
             "title":"OAK-FFC 4P PoE (NG2093 R2M0E2)",
             "description": "OAK-FFC 4P PoE based on NG2093 R2M0E2 board",
-            "eeprom":"eeprom/NG2093_R2M0E2_oak_ffc_4p_poe.json"
+            "eeprom":"eeprom/NG2093_R2M0E2_oak_ffc_4p_poe.json",
+            "board_config_file": "OAK-FFC-4P.json"
         },
         {
             "title":"OAK-FFC 4P PoE (NG2093 R1M0E1)",
             "description": "OAK-FFC 4P PoE based on NG2093 R1M0E1 board",
-            "eeprom":"eeprom/NG2093_R1M0E1_oak_ffc_4p_poe.json"
+            "eeprom":"eeprom/NG2093_R1M0E1_oak_ffc_4p_poe.json",
+            "board_config_file": "OAK-FFC-4P.json"
         }
     ]
 }

--- a/boards/OAK-FFC-1P.json
+++ b/boards/OAK-FFC-1P.json
@@ -1,0 +1,12 @@
+{
+    "board_config":
+    {
+        "name": "OAK-FFC-1P",
+        "cameras":{
+            "CAM_A": {
+                "name": "rgb",
+                "type": "color"
+            }
+        }
+    }
+}

--- a/boards/OAK-FFC-3P.json
+++ b/boards/OAK-FFC-3P.json
@@ -1,0 +1,20 @@
+{
+    "board_config":
+    {
+        "name": "OAK-FFC-3P",
+        "cameras":{
+            "CAM_A": {
+                "name": "rgb",
+                "type": "color"
+            },
+            "CAM_B": {
+                "name": "rgb",
+                "type": "color"
+            },
+            "CAM_C": {
+                "name": "rgb",
+                "type": "color"
+            }
+        }
+    }
+}

--- a/boards/OAK-FFC-4P.json
+++ b/boards/OAK-FFC-4P.json
@@ -1,0 +1,24 @@
+{
+    "board_config":
+    {
+        "name": "OAK-FFC-4P",
+        "cameras":{
+            "CAM_A": {
+                "name": "rgb",
+                "type": "color"
+            },
+            "CAM_B": {
+                "name": "rgb",
+                "type": "color"
+            },
+            "CAM_C": {
+                "name": "rgb",
+                "type": "color"
+            },
+            "CAM_D": {
+                "name": "rgb",
+                "type": "color"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added missing FFC camera configs for:

- OAK-FFC 4P PoE
- OAK-FFC 1P PoE

Defined all camera sockets for all multi-socket RVC2 FFCs:

- OAK-FFC 4P PoE
- OAK-FFC 4P
- OAK-FFC 3P