### PR TITLE
Added config for OAK-D Pro FF 97 (DM9098 R8M2E8)

### DIFF
--- a/batch/eeprom/DM9098_R8M2E8_oak_d_pro_ff_97.json
+++ b/batch/eeprom/DM9098_R8M2E8_oak_d_pro_ff_97.json
@@ -1,0 +1,12 @@
+{
+    "batchName": "",
+    "batchTime": 0,
+    "boardConf": "IR-C11M08-00",
+    "boardName": "DM9098",
+    "boardRev": "R8M2E8",
+    "productName": "OAK-D-PRO-FF-97",
+    "boardCustom": "",
+    "hardwareConf": "F1-FV00-BC000",
+    "boardOptions": 1048580,
+    "version": 7
+}

--- a/batch/oak_d_pro.json
+++ b/batch/oak_d_pro.json
@@ -24,6 +24,12 @@
             "board_config_file": "OAK-D-PRO-W.json"
         },
         {
+            "title":"OAK-D Pro FF 97 (DM9098 R8M2E8)",
+            "description": "OAK-D Pro, Fixed Focus, with center OV9782 camera",
+            "eeprom":"eeprom/DM9098_R8M2E8_oak_d_pro_ff_97.json",
+            "board_config_file": "OAK-D-PRO-97.json"
+        },
+        {
             "title":"OAK-D Pro W 97 (DM9098 R8M2E8)",
             "description": "OAK-D Pro Wide 97 with center OV9782 camera",
             "eeprom":"eeprom/DM9098_R8M2E8_oak_d_pro_w_97.json",


### PR DESCRIPTION
This config was missing in #72.