### PR TITLE
Fix IR boardConf spec for OAK-D-SR-PoE

### DIFF
--- a/batch/eeprom/EL2086_R0M0E0_oak_d_sr_poe.json
+++ b/batch/eeprom/EL2086_R0M0E0_oak_d_sr_poe.json
@@ -1,7 +1,7 @@
 {
     "batchName": "Maxwell",
     "batchTime": 0,
-    "boardConf": "nIR-C81M00-00",
+    "boardConf": "IR-C81M00-00",
     "boardName": "EL2086",
     "boardRev": "R0M0E0",
     "productName": "OAK-D-SR-POE",

--- a/batch/eeprom/EL2086_R1M1E1_oak_d_sr_poe.json
+++ b/batch/eeprom/EL2086_R1M1E1_oak_d_sr_poe.json
@@ -1,7 +1,7 @@
 {
     "batchName": "Maxwell",
     "batchTime": 0,
-    "boardConf": "nIR-C80M00-00",
+    "boardConf": "IR-C80M00-00",
     "boardName": "EL2086",
     "boardRev": "R1M1E1",
     "productName": "OAK-D-SR-POE",

--- a/batch/eeprom/EL2086_R2M2E2_oak_d_sr_poe.json
+++ b/batch/eeprom/EL2086_R2M2E2_oak_d_sr_poe.json
@@ -1,7 +1,7 @@
 {
     "batchName": "Maxwell",
     "batchTime": 0,
-    "boardConf": "nIR-C80M00-00",
+    "boardConf": "IR-C80M00-00",
     "boardName": "EL2086",
     "boardRev": "R2M2E2",
     "productName": "OAK-D-SR-POE",

--- a/batch/eeprom/EL2086_R3M2E3_oak_d_sr_poe.json
+++ b/batch/eeprom/EL2086_R3M2E3_oak_d_sr_poe.json
@@ -1,7 +1,7 @@
 {
     "batchName": "Maxwell",
     "batchTime": 0,
-    "boardConf": "nIR-C80M00-00",
+    "boardConf": "IR-C80M00-00",
     "boardName": "EL2086",
     "boardRev": "R3M2E3",
     "productName": "OAK-D-SR-POE",


### PR DESCRIPTION
Change `nIR`->`IR` for all SR-PoE, EL2086 R0-R3, as they all have IR flood + dot projector.