### PR TITLE
Use IR boardConf instead of nIR for oak d pro poe C32

### DIFF
--- a/batch/eeprom/NG9097_R4M2E4_BNO086_oak_d_pro_poe_ff_c32.json
+++ b/batch/eeprom/NG9097_R4M2E4_BNO086_oak_d_pro_poe_ff_c32.json
@@ -1,7 +1,7 @@
 {
     "batchName": "",
     "batchTime": 0,
-    "boardConf": "nIR-C21M08-00",
+    "boardConf": "IR-C21M08-00",
     "boardName": "NG9097",
     "boardRev": "R4M2E4",
     "productName": "OAK-D-PRO-POE-FF-C32",


### PR DESCRIPTION
Found by @alex-luxonis here:
https://github.com/luxonis/depthai-boards/pull/80