### PR TITLE
Added `nor_size` field to specify expected NOR size

### DIFF
--- a/batch/oak_d_sr_poe.json
+++ b/batch/oak_d_sr_poe.json
@@ -9,7 +9,8 @@
             "title":"OAK-D SR PoE (EL2086 R3M2E3)",
             "description": "OAK-D SR PoE, based on EL2086 R3M2E3 board with ToF sensor",
             "eeprom":"eeprom/EL2086_R3M2E3_oak_d_sr_poe.json",
-            "board_config_file": "OAK-D-SR-POE.json"
+            "board_config_file": "OAK-D-SR-POE.json",
+            "options": {"nor_size": 33554432}
         },
         {
             "title":"OAK-D SR PoE (EL2086 R2M2E2)",

--- a/boards_reader.py
+++ b/boards_reader.py
@@ -140,6 +140,9 @@ class Options(BaseModel):
 	eth: bool = False
 	"""Does the board support Ethernet? (Is it tested?)"""
 
+	nor_size: int = 0
+	"""Specify the size of the NOR flash."""
+
 	eeprom: bool = True
 	"""Should the eeprom be flashed?"""
 


### PR DESCRIPTION
Expected NOR size is optional in order to not break backwards compatibility, however, in the future it might be required. Setting a positive number will enable the check.

Specified expected NOR size for the OAK-D SR-PoE R3M2E3.