### PR TITLE
Add configs for OAK-D-W devices with DM9098 R8M2E8

### DIFF
--- a/batch/eeprom/DM9098_R8M2E8_oak_d_w.json
+++ b/batch/eeprom/DM9098_R8M2E8_oak_d_w.json
@@ -1,0 +1,13 @@
+{
+    "batchName": "Maxwell",
+    "batchTime": 0,
+    "boardConf": "nIR-C00M00-00",
+    "boardName": "DM9098",
+    "boardRev": "R8M2E8",
+    "productName": "OAK-D-W",
+    "boardCustom": "",
+    "hardwareConf": "F1-FV01-BC000",
+    "boardOptions": 1048580,
+    "version": 7
+}
+

--- a/batch/eeprom/DM9098_R8M2E8_oak_d_w_97.json
+++ b/batch/eeprom/DM9098_R8M2E8_oak_d_w_97.json
@@ -1,0 +1,13 @@
+{
+    "batchName": "",
+    "batchTime": 0,
+    "boardConf": "nIR-C11M08-00",
+    "boardName": "DM9098",
+    "boardRev": "R8M2E8",
+    "productName": "OAK-D-W-97",
+    "boardCustom": "",
+    "hardwareConf": "F1-FV01-BC000",
+    "boardOptions": 1048580,
+    "version": 7
+}
+

--- a/batch/oak_d_w.json
+++ b/batch/oak_d_w.json
@@ -6,6 +6,18 @@
     "options": {"bootloader": "header_usb", "imu": true},
     "variants": [
         {
+            "title":"OAK-D W (DM9098 R8M2E8)",
+            "description": "OAK-D Wide Lens, based on DM9098 R8M2E8 board",
+            "eeprom":"eeprom/DM9098_R8M2E8_oak_d_w.json",
+            "board_config_file": "OAK-D-W.json"
+        },
+        {
+            "title":"OAK-D W 97 (DM9098 R8M2E8)",
+            "description": "OAK-D W 97 based on DM9098 R8M2E8 board, with wide lens (OV9782 center camera)",
+            "eeprom":"eeprom/DM9098_R8M2E8_oak_d_w_97.json",
+            "board_config_file": "OAK-D-W-97.json"
+        },
+        {
             "title":"OAK-D W 97 (DM9098 R7M2E7)",
             "description": "OAK-D W 97 based on DM9098 R7M2E7 board, with wide lens (OV9782 center camera)",
             "eeprom":"eeprom/DM9098_R7M2E7_oak_d_w_97.json",


### PR DESCRIPTION
This PR adds configs for OAK-D W (DM9098 R8M2E8) and OAK-D W 97 (DM9098 R8M2E8).