### PR TITLE
Fix FFC-3P config

### DIFF
--- a/batch/eeprom/DM1090_R3M0E3_oak_ffc_3p.json
+++ b/batch/eeprom/DM1090_R3M0E3_oak_ffc_3p.json
@@ -1,7 +1,7 @@
 {
     "batchName": "",
     "batchTime": 0,
-    "boardConf": "IR-C00M05-00",
+    "boardConf": "nIR-C00M05-00",
     "boardName": "DM1090",
     "boardRev": "R3M0E3",
     "productName": "OAK-FFC-3P",

--- a/batch/oak_ffc_3p.json
+++ b/batch/oak_ffc_3p.json
@@ -3,7 +3,7 @@
     "description": "OAK FFC-3P",
     "image": "images/oak_d_ffc_3p.jpg",
     "test_type": "OAK-1",
-    "options": {"bootloader": "usb", "imu": true, "usb3": true},
+    "options": {"bootloader": "none", "imu": true, "usb3": true},
     "variants": [
         {
             "title":"OAK-FFC 3P (DM1090 R3M0E3)",


### PR DESCRIPTION
This PR fixes testing of FFC-3P. The device does not need its bootloader flashed (it has no flash memory) and it has no IR.