### PR TITLE
Use header_usb for OAK-FFC 4P

### DIFF
--- a/batch/oak_ffc_4p.json
+++ b/batch/oak_ffc_4p.json
@@ -3,7 +3,7 @@
     "description": "OAK FFC-4P",
     "image": "images/oak_d_ffc_4p.jpg",
     "test_type": "OAK-1",
-    "options": {"bootloader": "usb", "imu": true},
+    "options": {"bootloader": "header_usb", "imu": true},
     "variants": [
         {
             "title":"OAK-FFC 4P (DD2090 R7M1E7)",


### PR DESCRIPTION
This simple PR changes the bootloader type for FFC-4P to `header_usb`, as discussed on Slack.