### PR TITLE
Change IMU in OAK-D Lite boardConf

### DIFF
--- a/batch/eeprom/DM9095_R2M1E4_oak_d_lite_af.json
+++ b/batch/eeprom/DM9095_R2M1E4_oak_d_lite_af.json
@@ -1,7 +1,7 @@
 {
     "batchName": "",
     "batchTime": 0,
-    "boardConf": "nIR-C60M99-10",
+    "boardConf": "nIR-C60M99-01",
     "boardName": "DM9095",
     "boardRev": "R2M1E4",
     "productName": "OAK-D-LITE",

--- a/batch/eeprom/DM9095_R2M1E4_oak_d_lite_ff.json
+++ b/batch/eeprom/DM9095_R2M1E4_oak_d_lite_ff.json
@@ -1,7 +1,7 @@
 {
     "batchName": "",
     "batchTime": 0,
-    "boardConf": "nIR-C60M99-10",
+    "boardConf": "nIR-C60M99-01",
     "boardName": "DM9095",
     "boardRev": "R2M1E4",
     "productName": "OAK-D-LITE",

--- a/batch/eeprom/DM9095_R3M2E4_oak_d_lite_af.json
+++ b/batch/eeprom/DM9095_R3M2E4_oak_d_lite_af.json
@@ -1,7 +1,7 @@
 {
     "batchName": "",
     "batchTime": 0,
-    "boardConf": "nIR-C00M00-00",
+    "boardConf": "nIR-C00M00-01",
     "boardName": "DM9095",
     "boardRev": "R3M2E4",
     "productName": "OAK-D-LITE",

--- a/batch/eeprom/DM9095_R3M2E4_oak_d_lite_ff.json
+++ b/batch/eeprom/DM9095_R3M2E4_oak_d_lite_ff.json
@@ -1,7 +1,7 @@
 {
     "batchName": "",
     "batchTime": 0,
-    "boardConf": "nIR-C00M00-00",
+    "boardConf": "nIR-C00M00-01",
     "boardName": "DM9095",
     "boardRev": "R3M2E4",
     "productName": "OAK-D-LITE",

--- a/batch/eeprom/DM9095_R3M2E5_oak_d_lite_af.json
+++ b/batch/eeprom/DM9095_R3M2E5_oak_d_lite_af.json
@@ -1,7 +1,7 @@
 {
     "batchName": "",
     "batchTime": 0,
-    "boardConf": "nIR-C00M00-00",
+    "boardConf": "nIR-C00M00-01",
     "boardName": "DM9095",
     "boardRev": "R3M2E5",
     "productName": "OAK-D-LITE",

--- a/batch/eeprom/DM9095_R3M2E5_oak_d_lite_ff.json
+++ b/batch/eeprom/DM9095_R3M2E5_oak_d_lite_ff.json
@@ -1,7 +1,7 @@
 {
     "batchName": "",
     "batchTime": 0,
-    "boardConf": "nIR-C00M00-00",
+    "boardConf": "nIR-C00M00-01",
     "boardName": "DM9095",
     "boardRev": "R3M2E5",
     "productName": "OAK-D-LITE",


### PR DESCRIPTION
This fixes an issue where the BMI270 IMU was not properly specified in `boardConf` for OAK-D Lite devices.