### PR TITLE
Add ssh_password option

### DIFF
--- a/boards_reader.py
+++ b/boards_reader.py
@@ -184,6 +184,9 @@ class Options(BaseModel):
 	flash_mac_address: Optional[FlashMacAddressConfig] = None
 	""" Configuration for generating MAC addresses during flashing. """
 
+	ssh_password: str = ""
+	""" Password for SSH connection to the device. """
+
 class EepromData(BaseModel):
 	boardConf: Optional[str] = None
 	boardName: Optional[str] = None


### PR DESCRIPTION
This change allows specifying an ssh password that should be used for testing. This is needed for an upcoming customer production where the default password will be non-empty.