### PR TITLE
Flashing: Added ffc4p variant with USB BL preflashed.

### DIFF
--- a/batch/eeprom/DD2090_R7M1E7_oak_ffc_4p_usb_bl.json
+++ b/batch/eeprom/DD2090_R7M1E7_oak_ffc_4p_usb_bl.json
@@ -1,0 +1,12 @@
+{
+    "batchName": "",
+    "batchTime": 0,
+    "boardConf": "IR-C00M00-00",
+    "boardName": "DD2090",
+    "boardRev": "R7M1E7",
+    "productName": "OAK-FFC-4P",
+    "boardCustom": "",
+    "hardwareConf": "F0-FV00-BC000",
+    "boardOptions": 0,
+    "version": 7
+}

--- a/batch/oak_ffc_4p.json
+++ b/batch/oak_ffc_4p.json
@@ -6,6 +6,15 @@
     "options": {"bootloader": "header_usb", "imu": true},
     "variants": [
         {
+            "title":"OAK-FFC 4P (DD2090 R7M1E7) USB BL",
+            "description": "OAK-FFC 4P",
+            "eeprom":"eeprom/DD2090_R7M1E7_oak_ffc_4p_usb_bl.json",
+            "board_config_file": "OAK-FFC-4P.json",
+            "options": {
+                "bootloader": "usb"
+            }
+        },
+        {
             "title":"OAK-FFC 4P (DD2090 R7M1E7)",
             "description": "OAK-FFC 4P",
             "eeprom":"eeprom/DD2090_R7M1E7_oak_ffc_4p.json",

--- a/boards_reader.py
+++ b/boards_reader.py
@@ -368,7 +368,7 @@ for device_file in [*(DEPTHAI_BOARDS_PATH / "batch" ).glob("*.json"), *(DEPTHAI_
 		else:
 			variant_combined["board_config"] = {"cameras": {}} # if no board config is specified, use an empty one (used for FCC cameras)
 		# Convert the bootloader string to an enum
-		variant_combined["options"]["bootloader"] = BootloaderType(options["bootloader"]) # convert string to enum
+		variant_combined["options"]["bootloader"] = BootloaderType(variant_combined["options"]["bootloader"]) # convert string to enum
 
 		if "board_config_file_2" in variant_combined:
 			board_config_path = device_file.parent / "../boards" / variant_combined["board_config_file_2"]
@@ -381,8 +381,6 @@ for device_file in [*(DEPTHAI_BOARDS_PATH / "batch" ).glob("*.json"), *(DEPTHAI_
 					raise Exception(f"Couldn't load board config file at {board_config_path.resolve()} for device '{device_file.resolve()}'. Make sure the board_config_file field is set correctly in the device file.")
 		else:
 			variant_combined["board_config_2"] = {"cameras": {}} # if no board config is specified, use an empty one (used for FCC cameras)
-		# Convert the bootloader string to an enum
-		variant_combined["options"]["bootloader"] = BootloaderType(options["bootloader"]) # convert string to enum
 
 		variants_combined.append(variant_combined)
 


### PR DESCRIPTION
Fixed: combined variant creation didn't override the generic bootloader from the batch file with the variant specific bootloader.