### PR TITLE
Added new config variant + EEPROM files for OAK-D-S2 device

### DIFF
--- a/batch/eeprom/DM9098_R8M2E8_oak_d_s2_af.json
+++ b/batch/eeprom/DM9098_R8M2E8_oak_d_s2_af.json
@@ -1,0 +1,12 @@
+{
+    "batchName": "",
+    "batchTime": 0,
+    "boardConf": "nIR-C21M00-00",
+    "boardName": "DM9098",
+    "boardRev": "R8M2E8",
+    "productName": "OAK-D-S2-AF",
+    "boardCustom": "",
+    "hardwareConf": "F0-FV00-BC001",
+    "boardOptions": 1048580,
+    "version": 7
+}

--- a/batch/eeprom/DM9098_R8M2E8_oak_d_s2_af.json
+++ b/batch/eeprom/DM9098_R8M2E8_oak_d_s2_af.json
@@ -1,7 +1,7 @@
 {
     "batchName": "",
     "batchTime": 0,
-    "boardConf": "nIR-C21M00-00",
+    "boardConf": "nIR-C21M05-00",
     "boardName": "DM9098",
     "boardRev": "R8M2E8",
     "productName": "OAK-D-S2-AF",

--- a/batch/oak_d_s2.json
+++ b/batch/oak_d_s2.json
@@ -28,6 +28,12 @@
             "description": "OAK-D Series 2, FixedFocus, based on DM9098 R6M2E6 board, with PMIC IC",
             "eeprom":"eeprom/DM9098_R6M2E6_oak_d_s2_ff.json",
             "board_config_file": "OAK-D-S2.json"
+        },
+        {
+            "title":"OAK-D S2 AF (DM9098 R8M2E8)",
+            "description": "OAK-D Series 2, AutoFocus, based on DM9098 R8M2E8 board, with PMIC IC",
+            "eeprom":"eeprom/DM9098_R8M2E8_oak_d_s2_af.json",
+            "board_config_file": "OAK-D-S2.json"
         }
     ]
 }


### PR DESCRIPTION
Please review config. Not 100% sure whether memory segment is correct (in boardConf property) as I do not have this information right now.