### PR TITLE
Set OS as None by default

### DIFF
--- a/boards_reader.py
+++ b/boards_reader.py
@@ -302,7 +302,7 @@ class DeviceConfig(BaseModel):
 
 	description: str
 
-	os: Optional[str]
+	os: Optional[str] = None
 	"""The common OS which to use on all of this devices' variants, unless explicitly overwritten by the VariantConfig"""
 
 	variants: List[VariantConfig]


### PR DESCRIPTION
Add a default value to the OS `DeviceConfig` property, as it raised pydantic errors without it.