### PR TITLE
Add board variants with other CCM permutations

### DIFF
--- a/batch/eeprom/DM9098_R6M2E6_oak_d_pro_ff_97.json
+++ b/batch/eeprom/DM9098_R6M2E6_oak_d_pro_ff_97.json
@@ -7,6 +7,6 @@
     "productName": "OAK-D-PRO-FF-97",
     "boardCustom": "",
     "hardwareConf": "F1-FV00-BC001",
-    "boardOptions": 1048580,
+    "boardOptions": 4194308,
     "version": 7
 }

--- a/batch/eeprom/DM9098_R6M2E6_oak_d_pro_w_97.json
+++ b/batch/eeprom/DM9098_R6M2E6_oak_d_pro_w_97.json
@@ -7,7 +7,7 @@
     "productName": "OAK-D-PRO-W-97",
     "boardCustom": "",
     "hardwareConf": "F1-FV01-BC000",
-    "boardOptions": 1048580,
+    "boardOptions": 4194308,
     "version": 7
 }
 

--- a/batch/eeprom/DM9098_R6M2E6_oak_d_pro_w_ov9782.json
+++ b/batch/eeprom/DM9098_R6M2E6_oak_d_pro_w_ov9782.json
@@ -7,6 +7,6 @@
     "productName": "OAK-D-PRO-W-OV9782",
     "boardCustom": "",
     "hardwareConf": "F1-FV01-BC001",
-    "boardOptions": 1048580,
+    "boardOptions": 4194308,
     "version": 7
 }

--- a/batch/eeprom/DM9098_R7M2E7_oak_d_pro_ff_97.json
+++ b/batch/eeprom/DM9098_R7M2E7_oak_d_pro_ff_97.json
@@ -7,6 +7,6 @@
     "productName": "OAK-D-PRO-FF-97",
     "boardCustom": "",
     "hardwareConf": "F1-FV00-BC000",
-    "boardOptions": 1048580,
+    "boardOptions": 4194308,
     "version": 7
 }

--- a/batch/eeprom/DM9098_R7M2E7_oak_d_pro_w_97.json
+++ b/batch/eeprom/DM9098_R7M2E7_oak_d_pro_w_97.json
@@ -7,7 +7,7 @@
     "productName": "OAK-D-PRO-W-97",
     "boardCustom": "",
     "hardwareConf": "F1-FV01-BC000",
-    "boardOptions": 1048580,
+    "boardOptions": 4194308,
     "version": 7
 }
 

--- a/batch/eeprom/DM9098_R7M2E7_oak_d_w_97.json
+++ b/batch/eeprom/DM9098_R7M2E7_oak_d_w_97.json
@@ -7,7 +7,7 @@
     "productName": "OAK-D-W-97",
     "boardCustom": "",
     "hardwareConf": "F1-FV01-BC000",
-    "boardOptions": 1048580,
+    "boardOptions": 4194308,
     "version": 7
 }
 

--- a/batch/eeprom/DM9098_R8M2E8_oak_d_pro_ff_97.json
+++ b/batch/eeprom/DM9098_R8M2E8_oak_d_pro_ff_97.json
@@ -7,6 +7,6 @@
     "productName": "OAK-D-PRO-FF-97",
     "boardCustom": "",
     "hardwareConf": "F1-FV00-BC000",
-    "boardOptions": 1048580,
+    "boardOptions": 4194308,
     "version": 7
 }

--- a/batch/eeprom/DM9098_R8M2E8_oak_d_pro_w_97.json
+++ b/batch/eeprom/DM9098_R8M2E8_oak_d_pro_w_97.json
@@ -7,6 +7,6 @@
     "productName": "OAK-D-PRO-W-97",
     "boardCustom": "",
     "hardwareConf": "F1-FV01-BC000",
-    "boardOptions": 1048580,
+    "boardOptions": 4194308,
     "version": 7
 }

--- a/batch/eeprom/DM9098_R8M2E8_oak_d_w_97.json
+++ b/batch/eeprom/DM9098_R8M2E8_oak_d_w_97.json
@@ -7,7 +7,7 @@
     "productName": "OAK-D-W-97",
     "boardCustom": "",
     "hardwareConf": "F1-FV01-BC000",
-    "boardOptions": 1048580,
+    "boardOptions": 4194308,
     "version": 7
 }
 

--- a/batch/eeprom/EL2086_R3M2E3_oak_d_sr_poe_c83.json
+++ b/batch/eeprom/EL2086_R3M2E3_oak_d_sr_poe_c83.json
@@ -1,7 +1,7 @@
 {
     "batchName": "Maxwell",
     "batchTime": 0,
-    "boardConf": "IR-C84M00-00",
+    "boardConf": "IR-C83M00-00",
     "boardName": "EL2086",
     "boardRev": "R3M2E3",
     "productName": "OAK-D-SR-POE",

--- a/batch/eeprom/EL2086_R3M2E3_oak_d_sr_poe_c84.json
+++ b/batch/eeprom/EL2086_R3M2E3_oak_d_sr_poe_c84.json
@@ -1,0 +1,12 @@
+{
+    "batchName": "Maxwell",
+    "batchTime": 0,
+    "boardConf": "IR-C84M00-00",
+    "boardName": "EL2086",
+    "boardRev": "R3M2E3",
+    "productName": "OAK-D-SR-POE",
+    "boardCustom": "",
+    "hardwareConf": "F1-FV00-BC000",
+    "boardOptions": 6401,
+    "version": 7
+}

--- a/batch/oak_d_sr_poe.json
+++ b/batch/oak_d_sr_poe.json
@@ -15,7 +15,7 @@
         {
             "title":"OAK-D SR PoE (EL2086 R3M2E3) with IMX378",
             "description": "OAK-D SR PoE, based on EL2086 R3M2E3 board with IMX378 center and ToF",
-            "eeprom":"eeprom/EL2086_R3M2E3_oak_d_sr_poe_c84.json",
+            "eeprom":"eeprom/EL2086_R3M2E3_oak_d_sr_poe_c83.json",
             "board_config_file": "OAK-D-SR-POE.json",
             "options": {"nor_size": 33554432}
         },

--- a/batch/oak_d_sr_poe.json
+++ b/batch/oak_d_sr_poe.json
@@ -13,6 +13,13 @@
             "options": {"nor_size": 33554432}
         },
         {
+            "title":"OAK-D SR PoE (EL2086 R3M2E3) with IMX378",
+            "description": "OAK-D SR PoE, based on EL2086 R3M2E3 board with IMX378 center and ToF",
+            "eeprom":"eeprom/EL2086_R3M2E3_oak_d_sr_poe_c84.json",
+            "board_config_file": "OAK-D-SR-POE.json",
+            "options": {"nor_size": 33554432}
+        },
+        {
             "title":"OAK-D SR PoE (EL2086 R2M2E2)",
             "description": "OAK-D SR PoE, based on EL2086 R2M2E2 board with ToF sensor",
             "eeprom":"eeprom/EL2086_R2M2E2_oak_d_sr_poe.json",


### PR DESCRIPTION
- EL2086_R3M2E3_oak_d_sr_poe_c84 with CCM order L-to-R: OV9282, IMX378, S5K33D