### PR TITLE
OAK-T: Added R8 board with the inverted RST logic. (requires FW update)

### DIFF
--- a/batch/eeprom/MD2084_R8M6E5_oak_t.json
+++ b/batch/eeprom/MD2084_R8M6E5_oak_t.json
@@ -1,0 +1,12 @@
+{
+    "batchName": "",
+    "batchTime": 0,
+    "boardConf": "nIR-C55M11-01",
+    "boardName": "MD2084",
+    "boardRev": "R8M6E5",
+    "productName": "OAK-T",
+    "boardCustom": "",
+    "hardwareConf": "F1-FV04-BC000",
+    "boardOptions": 6401,
+    "version": 7
+}

--- a/batch/oak_t.json
+++ b/batch/oak_t.json
@@ -5,6 +5,12 @@
     "options": { "bootloader": "poe", "imu": true, "usb3": false, "eth": true },
     "variants": [
         {
+            "title": "OAK-T (MD2084 R8M6E5)",
+            "description": "OAK Thermal camera.",
+            "eeprom": "eeprom/MD2084_R8M6E5_oak_t.json",
+            "board_config_file": "OAK-T.json"
+        },
+        {
             "title": "OAK-T (MD2084 R7M6E4)",
             "description": "OAK Thermal camera.",
             "eeprom": "eeprom/MD2084_R7M6E4_oak_t.json",


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
A new revision of OAK-T will be produced soon.
The nRST pin has been inverted on the Myriadx side so that the sensor is shut off by default. This ensures that the sensor turns off when the pipeline ends.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
The boardName has been altered to `MD2084` from `MD2084-ASM`. The old board name will still work on the new FW. The new board name requires new FW / depthai release.

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
Tested locally with depthai-v3+new fw and [production depthai branch](https://github.com/luxonis/depthai-python/commit/51b0e4d88ea8ec88bbb634d730b9060730aba27c).