### PR TITLE
fix(batch oak4): update OAK4 os version to 1.20.5

### DIFF
--- a/batch/oak4_d.json
+++ b/batch/oak4_d.json
@@ -3,7 +3,7 @@
     "description": "OAK4-D",
     "image": "images/oak4_d.jpg",
     "test_type": "OAK4-D",
-    "os": "PRODUCTION/luxonis_os_rvc4_debug-1.18.3.tar.xz",
+    "os": "PRODUCTION/luxonis_os_rvc4-1.20.5.tar.xz",
     "options": {
         "imu": true,
         "platform": "rvc4",

--- a/batch/oak4_s.json
+++ b/batch/oak4_s.json
@@ -2,7 +2,7 @@
     "title": "OAK4-S",
     "description": "OAK4-S full assembly.",
     "image": "images/oak4-s.jpeg",
-    "os": "PRODUCTION/luxonis_os_rvc4_debug-1.18.3.tar.xz",
+    "os": "PRODUCTION/luxonis_os_rvc4-1.20.5.tar.xz",
     "options": {
         "platform": "rvc4",
         "environment": {


### PR DESCRIPTION
## Purpose
Per discussion for OAK4 MP1 use the os version 1.20.5

## Specification
None / not applicable

## Dependencies & Potential Impact
None / not applicable

## Deployment Plan
None / not applicable

## Testing & Validation

```bash
~ # oakctl list
+---+---------------+-------------------------+------------------------------------------------------+------------------------+---------------+-------+
| # | Serial Number | Device                  | Connection                                           | OS                     | Agent Version | Setup |
+=====================================================================================================================================================+
| 1 | 1264172198    | Luxonis, Inc. OAK4-D R7 | 192.168.1.139, 2001:b011:15:33dd:46a9:2cff:fe3f:2dca | Luxonis OS RVC4 1.20.5 | 0.17.0        | OK    |
+---+---------------+-------------------------+------------------------------------------------------+------------------------+---------------+-------+

```