### PR TITLE
New MAC address regions for oak4-d and oak4-s

### DIFF
--- a/batch/oak4_d.json
+++ b/batch/oak4_d.json
@@ -16,9 +16,9 @@
         "flash_mac_address": {
             "generating_method": "database_sourced",
             "config": {
-                "prefix": "44:A9:2C:30:00:00",
+                "prefix": "44:A9:2C:30:20:00",
                 "prefix_bits": 36,
-                "region_id": "RVC4"
+                "region_id": "RVC4_OAK4-D"
             }
         }
     },

--- a/batch/oak4_s.json
+++ b/batch/oak4_s.json
@@ -14,9 +14,9 @@
         "flash_mac_address": {
             "generating_method": "database_sourced",
             "config": {
-                "prefix": "44:A9:2C:30:00:00",
+                "prefix": "44:A9:2C:30:30:00",
                 "prefix_bits": 36,
-                "region_id": "RVC4"
+                "region_id": "RVC4_OAK4-S"
             }
         }
     },


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Defined new MAC regions for RVC4 devices since original region is now exhausted. Separated OAK4-D and OAK4-S each to own region, so we have more room. 

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
Instructions on MAC address generation maintained [here](https://docs.google.com/document/d/1_1OsVlMU5talLzNcvlIO9wX-d5gS4WvS1dAdp6FyJNw/edit?usp=sharing)

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
When approved and merged to production-tools master, each station will automatically switch to this region when updated.

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
Reflashed MAC address from new OAK4-S region without any issues (https://factory.luxonis.com/flashings/c9e435aa-a89b-48a7-ade7-7e1b8f640efd)