### PR TITLE
Fix OAK4 SKUs

### DIFF
--- a/batch/eeprom/NG9498_ASM_P10D0_oak4_d_af.json
+++ b/batch/eeprom/NG9498_ASM_P10D0_oak4_d_af.json
@@ -4,7 +4,7 @@
   "boardConf": "nIR-C56M52-03",
   "boardName": "NG9498-ASM",
   "boardRev": "P10D0",
-  "productName": "OAK4-D-AF",
+  "productName": "OAK-4-D-AF",
   "boardCustom": "",
   "hardwareConf": "F0-FV00-BC000",
   "boardOptions": 0,

--- a/batch/eeprom/NG9498_ASM_P10D0_oak4_d_ff.json
+++ b/batch/eeprom/NG9498_ASM_P10D0_oak4_d_ff.json
@@ -4,7 +4,7 @@
   "boardConf": "nIR-C56M52-03",
   "boardName": "NG9498-ASM",
   "boardRev": "P10D0",
-  "productName": "OAK4-D-FF",
+  "productName": "OAK-4-D-FF",
   "boardCustom": "",
   "hardwareConf": "F1-FV00-BC000",
   "boardOptions": 0,

--- a/batch/eeprom/NG9498_ASM_P10D0_oak4_d_pro_af.json
+++ b/batch/eeprom/NG9498_ASM_P10D0_oak4_d_pro_af.json
@@ -4,7 +4,7 @@
   "boardConf": "nIR-C56M52-03",
   "boardName": "NG9498-ASM",
   "boardRev": "P10D0",
-  "productName": "OAK4-D-PRO-AF",
+  "productName": "OAK-4-PRO-AF",
   "boardCustom": "",
   "hardwareConf": "F0-FV00-BC000",
   "boardOptions": 0,

--- a/batch/eeprom/NG9498_ASM_P10D0_oak4_d_pro_ff.json
+++ b/batch/eeprom/NG9498_ASM_P10D0_oak4_d_pro_ff.json
@@ -4,7 +4,7 @@
   "boardConf": "IR-C56M52-03",
   "boardName": "NG9498-ASM",
   "boardRev": "P10D0",
-  "productName": "OAK4-D-PRO-FF",
+  "productName": "OAK-4-PRO-FF",
   "boardCustom": "",
   "hardwareConf": "F1-FV00-BC000",
   "boardOptions": 0,

--- a/batch/eeprom/NG9498_ASM_P10D0_oak4_d_pro_w.json
+++ b/batch/eeprom/NG9498_ASM_P10D0_oak4_d_pro_w.json
@@ -4,7 +4,7 @@
   "boardConf": "IR-C56M52-03",
   "boardName": "NG9498-ASM",
   "boardRev": "P10D0",
-  "productName": "OAK4-D-PRO-W",
+  "productName": "OAK-4-PRO-W",
   "boardCustom": "",
   "hardwareConf": "F1-FV01-BC000",
   "boardOptions": 0,

--- a/batch/eeprom/NG9498_ASM_P10D0_oak4_d_w.json
+++ b/batch/eeprom/NG9498_ASM_P10D0_oak4_d_w.json
@@ -4,7 +4,7 @@
   "boardConf": "nIR-C56M52-03",
   "boardName": "NG9498-ASM",
   "boardRev": "P10D0",
-  "productName": "OAK4-D-W",
+  "productName": "OAK-4-D-W",
   "boardCustom": "",
   "hardwareConf": "F1-FV01-BC000",
   "boardOptions": 0,

--- a/batch/eeprom/NG9498_ASM_P7D1_oak4_d_af.json
+++ b/batch/eeprom/NG9498_ASM_P7D1_oak4_d_af.json
@@ -4,7 +4,7 @@
   "boardConf": "nIR-C56M52-03",
   "boardName": "NG9498-ASM",
   "boardRev": "P7D1",
-  "productName": "OAK4-D-AF",
+  "productName": "OAK-4-D-AF",
   "boardCustom": "",
   "hardwareConf": "F0-FV00-BC000",
   "boardOptions": 0,

--- a/batch/eeprom/NG9498_ASM_P7D1_oak4_d_ff.json
+++ b/batch/eeprom/NG9498_ASM_P7D1_oak4_d_ff.json
@@ -4,7 +4,7 @@
   "boardConf": "nIR-C56M52-03",
   "boardName": "NG9498-ASM",
   "boardRev": "P7D1",
-  "productName": "OAK4-D-FF",
+  "productName": "OAK-4-D-FF",
   "boardCustom": "",
   "hardwareConf": "F1-FV00-BC000",
   "boardOptions": 0,

--- a/batch/eeprom/NG9498_ASM_P7D1_oak4_d_pro_af.json
+++ b/batch/eeprom/NG9498_ASM_P7D1_oak4_d_pro_af.json
@@ -4,7 +4,7 @@
   "boardConf": "nIR-C56M52-03",
   "boardName": "NG9498-ASM",
   "boardRev": "P7D1",
-  "productName": "OAK4-D-PRO-AF",
+  "productName": "OAK-4-PRO-AF",
   "boardCustom": "",
   "hardwareConf": "F0-FV00-BC000",
   "boardOptions": 0,

--- a/batch/eeprom/NG9498_ASM_P7D1_oak4_d_pro_ff.json
+++ b/batch/eeprom/NG9498_ASM_P7D1_oak4_d_pro_ff.json
@@ -4,7 +4,7 @@
   "boardConf": "IR-C56M52-03",
   "boardName": "NG9498-ASM",
   "boardRev": "P7D1",
-  "productName": "OAK4-D-PRO-FF",
+  "productName": "OAK-4-PRO-FF",
   "boardCustom": "",
   "hardwareConf": "F1-FV00-BC000",
   "boardOptions": 0,

--- a/batch/eeprom/NG9498_ASM_P7D1_oak4_d_pro_w.json
+++ b/batch/eeprom/NG9498_ASM_P7D1_oak4_d_pro_w.json
@@ -4,7 +4,7 @@
   "boardConf": "IR-C56M52-03",
   "boardName": "NG9498-ASM",
   "boardRev": "P7D1",
-  "productName": "OAK4-D-PRO-W",
+  "productName": "OAK-4-PRO-W",
   "boardCustom": "",
   "hardwareConf": "F1-FV01-BC000",
   "boardOptions": 0,

--- a/batch/eeprom/NG9498_ASM_P7D1_oak4_d_w.json
+++ b/batch/eeprom/NG9498_ASM_P7D1_oak4_d_w.json
@@ -4,7 +4,7 @@
   "boardConf": "nIR-C56M52-03",
   "boardName": "NG9498-ASM",
   "boardRev": "P7D1",
-  "productName": "OAK4-D-W",
+  "productName": "OAK-4-D-W",
   "boardCustom": "",
   "hardwareConf": "F1-FV01-BC000",
   "boardOptions": 0,

--- a/batch/eeprom/NG9498_ASM_P9D1_oak4_d_af.json
+++ b/batch/eeprom/NG9498_ASM_P9D1_oak4_d_af.json
@@ -4,7 +4,7 @@
   "boardConf": "nIR-C56M52-03",
   "boardName": "NG9498-ASM",
   "boardRev": "P9D1",
-  "productName": "OAK4-D-AF",
+  "productName": "OAK-4-D-AF",
   "boardCustom": "",
   "hardwareConf": "F0-FV00-BC000",
   "boardOptions": 0,

--- a/batch/eeprom/NG9498_ASM_P9D1_oak4_d_ff.json
+++ b/batch/eeprom/NG9498_ASM_P9D1_oak4_d_ff.json
@@ -4,7 +4,7 @@
   "boardConf": "nIR-C56M52-03",
   "boardName": "NG9498-ASM",
   "boardRev": "P9D1",
-  "productName": "OAK4-D-FF",
+  "productName": "OAK-4-D-FF",
   "boardCustom": "",
   "hardwareConf": "F1-FV00-BC000",
   "boardOptions": 0,

--- a/batch/eeprom/NG9498_ASM_P9D1_oak4_d_pro_af.json
+++ b/batch/eeprom/NG9498_ASM_P9D1_oak4_d_pro_af.json
@@ -4,7 +4,7 @@
   "boardConf": "nIR-C56M52-03",
   "boardName": "NG9498-ASM",
   "boardRev": "P9D1",
-  "productName": "OAK4-D-PRO-AF",
+  "productName": "OAK-4-PRO-AF",
   "boardCustom": "",
   "hardwareConf": "F0-FV00-BC000",
   "boardOptions": 0,

--- a/batch/eeprom/NG9498_ASM_P9D1_oak4_d_pro_ff.json
+++ b/batch/eeprom/NG9498_ASM_P9D1_oak4_d_pro_ff.json
@@ -4,7 +4,7 @@
   "boardConf": "IR-C56M52-03",
   "boardName": "NG9498-ASM",
   "boardRev": "P9D1",
-  "productName": "OAK4-D-PRO-FF",
+  "productName": "OAK-4-PRO-FF",
   "boardCustom": "",
   "hardwareConf": "F1-FV00-BC000",
   "boardOptions": 0,

--- a/batch/eeprom/NG9498_ASM_P9D1_oak4_d_pro_w.json
+++ b/batch/eeprom/NG9498_ASM_P9D1_oak4_d_pro_w.json
@@ -4,7 +4,7 @@
   "boardConf": "IR-C56M52-03",
   "boardName": "NG9498-ASM",
   "boardRev": "P9D1",
-  "productName": "OAK4-D-PRO-W",
+  "productName": "OAK-4-PRO-W",
   "boardCustom": "",
   "hardwareConf": "F1-FV01-BC000",
   "boardOptions": 0,

--- a/batch/eeprom/NG9498_ASM_P9D1_oak4_d_w.json
+++ b/batch/eeprom/NG9498_ASM_P9D1_oak4_d_w.json
@@ -4,7 +4,7 @@
   "boardConf": "nIR-C56M52-03",
   "boardName": "NG9498-ASM",
   "boardRev": "P9D1",
-  "productName": "OAK4-D-W",
+  "productName": "OAK-4-D-W",
   "boardCustom": "",
   "hardwareConf": "F1-FV01-BC000",
   "boardOptions": 0,

--- a/batch/eeprom/SL3443_ASM_P10D1_oak4_s_af.json
+++ b/batch/eeprom/SL3443_ASM_P10D1_oak4_s_af.json
@@ -4,7 +4,7 @@
   "boardConf": "nIR-C45M52-03",
   "boardName": "SL3443-ASM",
   "boardRev": "P10D1",
-  "productName": "OAK4-S-AF",
+  "productName": "OAK-4-S-AF",
   "boardCustom": "",
   "hardwareConf": "F0-FV00-BC000",
   "boardOptions": 0,

--- a/batch/eeprom/SL3443_ASM_P10D1_oak4_s_ff.json
+++ b/batch/eeprom/SL3443_ASM_P10D1_oak4_s_ff.json
@@ -4,7 +4,7 @@
   "boardConf": "nIR-C45M52-03",
   "boardName": "SL3443-ASM",
   "boardRev": "P10D1",
-  "productName": "OAK4-S-FF",
+  "productName": "OAK-4-S-FF",
   "boardCustom": "",
   "hardwareConf": "F1-FV00-BC000",
   "boardOptions": 0,

--- a/batch/eeprom/SL3443_ASM_P10D1_oak4_s_w.json
+++ b/batch/eeprom/SL3443_ASM_P10D1_oak4_s_w.json
@@ -4,7 +4,7 @@
   "boardConf": "nIR-C45M52-03",
   "boardName": "SL3443-ASM",
   "boardRev": "P10D1",
-  "productName": "OAK4-S-W",
+  "productName": "OAK-4-S-W",
   "boardCustom": "",
   "hardwareConf": "F1-FV01-BC000",
   "boardOptions": 0,

--- a/batch/eeprom/SL3443_ASM_P5D1_oak4_s_af.json
+++ b/batch/eeprom/SL3443_ASM_P5D1_oak4_s_af.json
@@ -4,7 +4,7 @@
   "boardConf": "nIR-C45M52-03",
   "boardName": "SL3443-ASM",
   "boardRev": "P5D1",
-  "productName": "OAK4-S-AF",
+  "productName": "OAK-4-S-AF",
   "boardCustom": "",
   "hardwareConf": "F0-FV00-BC000",
   "boardOptions": 0,

--- a/batch/eeprom/SL3443_ASM_P5D1_oak4_s_ff.json
+++ b/batch/eeprom/SL3443_ASM_P5D1_oak4_s_ff.json
@@ -4,7 +4,7 @@
   "boardConf": "nIR-C45M52-03",
   "boardName": "SL3443-ASM",
   "boardRev": "P5D1",
-  "productName": "OAK4-S-FF",
+  "productName": "OAK-4-S-FF",
   "boardCustom": "",
   "hardwareConf": "F1-FV00-BC000",
   "boardOptions": 0,

--- a/batch/eeprom/SL3443_ASM_P5D1_oak4_s_w.json
+++ b/batch/eeprom/SL3443_ASM_P5D1_oak4_s_w.json
@@ -4,7 +4,7 @@
   "boardConf": "nIR-C45M52-03",
   "boardName": "SL3443-ASM",
   "boardRev": "P5D1",
-  "productName": "OAK4-S-W",
+  "productName": "OAK-4-S-W",
   "boardCustom": "",
   "hardwareConf": "F1-FV01-BC000",
   "boardOptions": 0,

--- a/batch/eeprom/SL3443_ASM_P9D1_oak4_s_af.json
+++ b/batch/eeprom/SL3443_ASM_P9D1_oak4_s_af.json
@@ -4,7 +4,7 @@
   "boardConf": "nIR-C45M52-03",
   "boardName": "SL3443-ASM",
   "boardRev": "P9D1",
-  "productName": "OAK4-S-AF",
+  "productName": "OAK-4-S-AF",
   "boardCustom": "",
   "hardwareConf": "F0-FV00-BC000",
   "boardOptions": 0,

--- a/batch/eeprom/SL3443_ASM_P9D1_oak4_s_ff.json
+++ b/batch/eeprom/SL3443_ASM_P9D1_oak4_s_ff.json
@@ -4,7 +4,7 @@
   "boardConf": "nIR-C45M52-03",
   "boardName": "SL3443-ASM",
   "boardRev": "P9D1",
-  "productName": "OAK4-S-FF",
+  "productName": "OAK-4-S-FF",
   "boardCustom": "",
   "hardwareConf": "F1-FV00-BC000",
   "boardOptions": 0,

--- a/batch/eeprom/SL3443_ASM_P9D1_oak4_s_w.json
+++ b/batch/eeprom/SL3443_ASM_P9D1_oak4_s_w.json
@@ -4,7 +4,7 @@
   "boardConf": "nIR-C45M52-03",
   "boardName": "SL3443-ASM",
   "boardRev": "P9D1",
-  "productName": "OAK4-S-W",
+  "productName": "OAK-4-S-W",
   "boardCustom": "",
   "hardwareConf": "F1-FV01-BC000",
   "boardOptions": 0,


### PR DESCRIPTION
## Purpose
Change the OAK4 SKUs to fix naming inconsistencies between the eeprom and shop
1. Add a hyphen before the 4 (OAK4 -> OAK-4)
2. Drop the D for PRO variants (OAK4-D-PRO -> OAK-4-PRO)
