### PR TITLE
Updating all FOV to match the shop

### DIFF
--- a/boards/OAK-1-MAX.json
+++ b/boards/OAK-1-MAX.json
@@ -6,7 +6,7 @@
         "cameras":{
             "CAM_A": {
                 "name": "color",
-                "hfov": 68.7938,
+                "hfov": 45.0,
                 "type": "color"
             }
         }

--- a/boards/OAK-1-POE.json
+++ b/boards/OAK-1-POE.json
@@ -6,10 +6,9 @@
         "cameras":{
             "CAM_A": {
                 "name": "color",
-                "hfov": 68.7938,
+                "hfov": 66.0,
                 "type": "color"
             }
         }
     }
 }
-

--- a/boards/OAK-1.json
+++ b/boards/OAK-1.json
@@ -6,7 +6,7 @@
         "cameras":{
             "CAM_A": {
                 "name": "color",
-                "hfov": 68.7938,
+                "hfov": 66.0,
                 "type": "color"
             }
         }

--- a/boards/OAK-D-CM4-POE.json
+++ b/boards/OAK-D-CM4-POE.json
@@ -5,12 +5,12 @@
         "cameras":{
             "CAM_A": {
                 "name": "color",
-                "hfov": 68.7938,
+                "hfov": 69.0,
                 "type": "color"
             },
             "CAM_B": {
                 "name": "left",
-                "hfov": 71.86,
+                "hfov": 72.0,
                 "type": "mono",
                 "extrinsics": {
                     "to_cam": "CAM_C",
@@ -28,7 +28,7 @@
             },
             "CAM_C": {
                 "name": "right",
-                "hfov": 71.86,
+                "hfov": 72.0,
                 "type": "mono",
                 "extrinsics": {
                     "to_cam": "CAM_A",

--- a/boards/OAK-D-LITE.json
+++ b/boards/OAK-D-LITE.json
@@ -6,12 +6,12 @@
         "cameras":{
             "CAM_A": {
                 "name": "color",
-                "hfov": 68.7938,
+                "hfov": 69.0,
                 "type": "color"
             },
             "CAM_B": {
                 "name": "left",
-                "hfov": 72.9,
+                "hfov": 73.0,
                 "type": "mono",
                 "extrinsics": {
                     "to_cam": "CAM_C",
@@ -29,7 +29,7 @@
             },
             "CAM_C": {
                 "name": "right",
-                "hfov": 72.9,
+                "hfov": 73.0,
                 "type": "mono",
                 "extrinsics": {
                     "to_cam": "CAM_A",
@@ -89,5 +89,4 @@
         }
     }
 }
-
 

--- a/boards/OAK-D-LR.json
+++ b/boards/OAK-D-LR.json
@@ -5,7 +5,7 @@
         "cameras":{
             "CAM_B": {
                 "name": "left",
-                "hfov": 77.3,
+                "hfov": 82.0,
                 "type": "color",
                 "extrinsics": {
                     "to_cam": "CAM_C",
@@ -25,7 +25,7 @@
             },
             "CAM_C": {
                 "name": "right",
-                "hfov":  77.3,
+                "hfov":  82.0,
                 "type": "color",
                 "extrinsics": {
                     "to_cam": "CAM_A",
@@ -43,7 +43,7 @@
             },
             "CAM_A": {
                 "name": "center",
-                "hfov":  77.3,
+                "hfov":  82.0,
                 "type": "color"
             }
         },

--- a/boards/OAK-D-POE.json
+++ b/boards/OAK-D-POE.json
@@ -6,12 +6,12 @@
         "cameras":{
             "CAM_A": {
                 "name": "color",
-                "hfov": 68.7938,
+                "hfov": 66.0,
                 "type": "color"
             },
             "CAM_B": {
                 "name": "left",
-                "hfov": 71.86,
+                "hfov": 80.0,
                 "type": "mono",
                 "extrinsics": {
                     "to_cam": "CAM_C",
@@ -29,7 +29,7 @@
             },
             "CAM_C": {
                 "name": "right",
-                "hfov": 71.86,
+                "hfov": 80.0,
                 "type": "mono",
                 "extrinsics": {
                     "to_cam": "CAM_A",
@@ -73,4 +73,3 @@
         }
     }
 }
-

--- a/boards/OAK-D-S2-POE.json
+++ b/boards/OAK-D-S2-POE.json
@@ -6,12 +6,12 @@
         "cameras":{
             "CAM_A": {
                 "name": "color",
-                "hfov": 68.7938,
+                "hfov": 66.0,
                 "type": "color"
             },
             "CAM_B": {
                 "name": "left",
-                "hfov": 71.86,
+                "hfov": 80.0,
                 "type": "mono",
                 "extrinsics": {
                     "to_cam": "CAM_C",
@@ -29,7 +29,7 @@
             },
             "CAM_C": {
                 "name": "right",
-                "hfov": 71.86,
+                "hfov": 80.0,
                 "type": "mono",
                 "extrinsics": {
                     "to_cam": "CAM_A",
@@ -89,4 +89,3 @@
         }
     }
 }
-

--- a/boards/OAK-D-S2.json
+++ b/boards/OAK-D-S2.json
@@ -6,12 +6,12 @@
         "cameras":{
             "CAM_A": {
                 "name": "color",
-                "hfov": 68.7938,
+                "hfov": 66.0,
                 "type": "color"
             },
             "CAM_B": {
                 "name": "left",
-                "hfov": 71.86,
+                "hfov": 80.0,
                 "type": "mono",
                 "extrinsics": {
                     "to_cam": "CAM_C",
@@ -29,7 +29,7 @@
             },
             "CAM_C": {
                 "name": "right",
-                "hfov": 71.86,
+                "hfov": 80.0,
                 "type": "mono",
                 "extrinsics": {
                     "to_cam": "CAM_A",
@@ -89,4 +89,3 @@
         }
     }
 }
-

--- a/boards/OAK-D-SR-POE.json
+++ b/boards/OAK-D-SR-POE.json
@@ -6,7 +6,7 @@
         "cameras":{
             "CAM_B": {
                 "name": "left",
-                "hfov": 71.86,
+                "hfov": 80.0,
                 "type": "color",
                 "extrinsics": {
                     "to_cam": "CAM_C",
@@ -24,7 +24,7 @@
             },
             "CAM_C": {
                 "name": "right",
-                "hfov": 71.86,
+                "hfov": 80.0,
                 "type": "color",
                 "extrinsics": {
                     "to_cam": "CAM_A",
@@ -42,7 +42,7 @@
             },
             "CAM_A": {
                 "name": "tof",
-                "hfov": 71.86,
+                "hfov": 80.0,
                 "type": "tof"
             }
         },

--- a/boards/OAK-D-SR.json
+++ b/boards/OAK-D-SR.json
@@ -6,7 +6,7 @@
         "cameras":{
             "CAM_B": {
                 "name": "left",
-                "hfov": 71.86,
+                "hfov": 80.0,
                 "type": "color",
                 "extrinsics": {
                     "to_cam": "CAM_C",
@@ -26,7 +26,7 @@
             },
             "CAM_C": {
                 "name": "right",
-                "hfov": 71.86,
+                "hfov": 80.0,
                 "type": "color"
             }
 

--- a/boards/OAK-D.json
+++ b/boards/OAK-D.json
@@ -5,12 +5,12 @@
         "cameras":{
             "CAM_A": {
                 "name": "color",
-                "hfov": 68.7938,
+                "hfov": 69.0,
                 "type": "color"
             },
             "CAM_B": {
                 "name": "left",
-                "hfov": 71.86,
+                "hfov": 72.0,
                 "type": "mono",
                 "extrinsics": {
                     "to_cam": "CAM_C",
@@ -28,7 +28,7 @@
             },
             "CAM_C": {
                 "name": "right",
-                "hfov": 71.86,
+                "hfov": 72.0,
                 "type": "mono",
                 "extrinsics": {
                     "to_cam": "CAM_A",
@@ -51,4 +51,3 @@
         }
     }
 }
-


### PR DESCRIPTION
The values in the depthAI boards did not match with the values in the shop itself so they needed to be updated
https://shop.luxonis.com/products/

Applied HFOV values:

OAK-D / OAK-D-CM4-POE: 69 / 72 / 72
OAK-D-POE: 66 / 80 / 80
OAK-D-LITE: 69 / 73 / 73
OAK-D-S2 / OAK-D-S2-POE: 66 / 80 / 80
OAK-1 / OAK-1-POE: 66
OAK-1-MAX: 45
OAK-D-SR / OAK-D-SR-POE: 80
OAK-D-LR: 82
