### PR TITLE
OAK-D-SR-POE: Fixed relative extrinsics link

### DIFF
--- a/boards/OAK-D-SR-POE.json
+++ b/boards/OAK-D-SR-POE.json
@@ -56,7 +56,7 @@
                 "BNO": {
                     "name" : "BNO086",
                     "extrinsics": {
-                        "to_cam": "LEFT",
+                        "to_cam": "CAM_B",
                         "specTranslation": {
                             "x": 0.2915,
                             "y": -0.069,


### PR DESCRIPTION
## Purpose
Fix invalid extrinsics (it points to a non-existent sensor LEFT).

## Specification
OAK-D-SR-POE 

## Dependencies & Potential Impact
It un-breaks automated parsing of the JSON.

## Deployment Plan
None / not applicable

## Testing & Validation
Tested with my local parsing script.