### PR TITLE
fix(OAK-D-W-POE-C57): disable color camera since no such ccm

### DIFF
--- a/batch/oak_d_poe.json
+++ b/batch/oak_d_poe.json
@@ -81,6 +81,7 @@
             "title":"OAK-D-W-POE-C57 (NG9097 R4M2E4)",
             "description": "OAK-D-W-POE-C57 based on NG9097 R4M2E4 (OAK-D-W-POE without RGB CCM)",
             "eeprom":"eeprom/NG9097_R4M2E4_BNO086_oak_d_w_poe_c57.json",
+            "options": {"jpeg": false},
             "board_config_file": "OAK-D-W-POE-C57.json"
         }
     ]


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

To remove the center camera test item on OAK-D-W-POE-C57 since the CCM does not exits in this SKU

<img width="574" height="606" alt="image" src="https://github.com/user-attachments/assets/6e1cbec9-9620-4694-8459-65baa49bfafe" />

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable